### PR TITLE
fixed white box sizing issue when window gets smaller

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
 
 
   <div class="w3-row">
-    <div class="w3-half w3-pale-blue w3-container w3-text-blue-grey w3-center" style="min-height: 1020px">
+    <div class="w3-half w3-pale-blue w3-container w3-text-blue-grey w3-center" style="min-height: 1102px">
       <div class="w3-padding-16">
         <h1><b><i>Welcome to Patrick Canny's Homepage!</i></b></h1>
         <img src="picture.jpg" class="w3-margin w3-circle" alt="Person" style="width:60%">
@@ -27,7 +27,7 @@
         <a href="#contact" class="w3-button w3-transparent w3-block w3-hover-blue-grey w3-padding-16">Contact</a>
       </div>
     </div>
-    <div class="w3-half w3-pale-blue w3-container w3-text-blue-grey" style="min-height:1020px">
+    <div class="w3-half w3-pale-blue w3-container w3-text-blue-grey" style="min-height:1102px">
       <div class="w3-padding-32 w3-center">
         <h1><i>About Me</i></h1>
         <img src="yoyo.jpg" class="w3-margin w3-circle" alt="Person" style="width:50%">


### PR DESCRIPTION
You had the max-height set to 1020, however, your text in the right column was over loading this expanding it to 1102. So while the right column filled the div when height was 1102, the left column stopped at 1020. Best way to fix this is to let the left column stretch to the height of the right column.